### PR TITLE
update comment to reflect use of NAU7802_SPS_80

### DIFF
--- a/src/SparkFun_Qwiic_Scale_NAU7802_Arduino_Library.cpp
+++ b/src/SparkFun_Qwiic_Scale_NAU7802_Arduino_Library.cpp
@@ -56,7 +56,7 @@ bool NAU7802::begin(TwoWire &wirePort, bool initialize)
 
     result &= setGain(NAU7802_GAIN_128); //Set gain to 128
 
-    result &= setSampleRate(NAU7802_SPS_80); //Set samples per second to 10
+    result &= setSampleRate(NAU7802_SPS_80); //Set samples per second to 80
 
     //Turn off CLK_CHP. From 9.1 power on sequencing.
     uint8_t adc = getRegister(NAU7802_ADC);


### PR DESCRIPTION
The comment here claims to select 10 samples per second (the default according to the data sheet), but the code is selecting 80. Update the comment.